### PR TITLE
Add checkpointing and resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ int main() {
 
 See `src/main.cpp` for a complete example.
 
+### Checkpointing
+The `train_compression.py` script writes checkpoints to the `models/` directory.
+Every run saves `latest.pth` and `best.pth` so training can resume where it left
+off. By default the next invocation will load `latest.pth` and continue
+training. Use `--no-resume` to start from scratch or `--save-all` to keep a
+checkpoint for every epoch.
+
 ## Motivation
 QuatNet was inspired by the ICLR 2019 paper [*Quaternion Recurrent Neural Networks*](https://arxiv.org/abs/1806.04418), which noted that Quaternion neural networks, while computationally intensive due to the Hamilton product, could outperform real-valued networks with a properly engineered CUDA kernel. The **HamProd Kernel** addresses this by providing a high-performance, GPU-accelerated implementation, enabling QNNs to process data with fewer parameters and faster training/inference times.
 

--- a/train_compression.py
+++ b/train_compression.py
@@ -23,7 +23,33 @@ class CompressionAutoencoder(nn.Module):
         return self.decoder(encoded)
 
 
-def train_model(model: nn.Module, train_loader, test_loader, *, num_epochs: int = 10, learning_rate: float = 1e-3, device: torch.device = torch.device('cpu'), save_dir: str = 'models'):
+def train_model(
+    model: nn.Module,
+    train_loader,
+    test_loader,
+    *,
+    num_epochs: int = 10,
+    learning_rate: float = 1e-3,
+    device: torch.device = torch.device("cpu"),
+    save_dir: str = "models",
+    resume: bool = True,
+    save_all: bool = False,
+):
+    """Train the autoencoder with checkpointing.
+
+    Args:
+        model: The neural network to train.
+        train_loader: DataLoader for training data.
+        test_loader: DataLoader for validation.
+        num_epochs: Number of additional epochs to train.
+        learning_rate: Optimizer learning rate.
+        device: Torch device to use.
+        save_dir: Directory where checkpoints are stored.
+        resume: If True, resume from ``latest.pth`` in ``save_dir`` when present.
+        save_all: If True, keep a checkpoint for every epoch in addition to
+            ``latest.pth`` and ``best.pth``.
+    """
+
     logger.info("Starting training on %s", device)
     model.to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
@@ -31,7 +57,20 @@ def train_model(model: nn.Module, train_loader, test_loader, *, num_epochs: int 
     save_path = Path(save_dir)
     save_path.mkdir(parents=True, exist_ok=True)
 
-    for epoch in range(num_epochs):
+    latest_file = save_path / "latest.pth"
+    best_file = save_path / "best.pth"
+    start_epoch = 0
+    best_loss = float("inf")
+
+    if resume and latest_file.exists():
+        logger.info("Resuming from %s", latest_file)
+        ckpt = torch.load(latest_file, map_location=device)
+        model.load_state_dict(ckpt["model_state"])
+        start_epoch = ckpt.get("epoch", -1) + 1
+        best_loss = ckpt.get("best_loss", best_loss)
+        logger.info("Resumed at epoch %d with best loss %.6f", start_epoch, best_loss)
+
+    for epoch in range(start_epoch, start_epoch + num_epochs):
         model.train()
         epoch_loss = 0.0
         start = time.time()
@@ -58,17 +97,53 @@ def train_model(model: nn.Module, train_loader, test_loader, *, num_epochs: int 
                 batch[:, :, 0] = 0.0
                 out = model(batch)
                 val_loss += criterion(out[:, :, 1:], batch[:, :, 1:]).item()
-        logger.info("Epoch %d validation loss %.6f", epoch + 1, val_loss / len(test_loader))
-        torch.save(model.state_dict(), save_path / f"checkpoint_epoch_{epoch+1}.pth")
+        val_loss /= len(test_loader)
+        logger.info("Epoch %d validation loss %.6f", epoch + 1, val_loss)
+
+        # Save checkpoints
+        is_best = val_loss < best_loss
+        if is_best:
+            best_loss = val_loss
+            torch.save(
+                {"epoch": epoch, "model_state": model.state_dict(), "best_loss": best_loss},
+                best_file,
+            )
+            logger.info("Saved new best checkpoint to %s", best_file)
+
+        torch.save(
+            {"epoch": epoch, "model_state": model.state_dict(), "best_loss": best_loss},
+            latest_file,
+        )
+
+        if save_all:
+            torch.save(model.state_dict(), save_path / f"checkpoint_epoch_{epoch+1}.pth")
 
 
 if __name__ == "__main__":
+    import argparse
+
     PATCH_SIZE = 4
     INPUT_Q = PATCH_SIZE * PATCH_SIZE
     HIDDEN_Q = 4
 
-    train_loader, test_loader = create_data_loaders('data/train', 'data/test', batch_size=256, patch_size=PATCH_SIZE)
+    parser = argparse.ArgumentParser(description="Train quaternion compression autoencoder")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of epochs to train")
+    parser.add_argument("--save-dir", type=str, default="models", help="Directory for checkpoints")
+    parser.add_argument("--no-resume", action="store_true", help="Do not resume from latest checkpoint")
+    parser.add_argument("--save-all", action="store_true", help="Keep checkpoint for every epoch")
+    args = parser.parse_args()
 
-    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    train_loader, test_loader = create_data_loaders("data/train", "data/test", batch_size=256, patch_size=PATCH_SIZE)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model = CompressionAutoencoder(INPUT_Q, HIDDEN_Q)
-    train_model(model, train_loader, test_loader, num_epochs=10, device=device)
+    train_model(
+        model,
+        train_loader,
+        test_loader,
+        num_epochs=args.epochs,
+        device=device,
+        save_dir=args.save_dir,
+        resume=not args.no_resume,
+        save_all=args.save_all,
+    )


### PR DESCRIPTION
## Summary
- implement checkpointing with latest and best model files
- add optional CLI flags to resume training or keep all checkpoints
- document checkpointing in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*