### PR TITLE
Improve checkpoint resume logic

### DIFF
--- a/train_compression.py
+++ b/train_compression.py
@@ -51,6 +51,9 @@ def train_model(
     """
 
     logger.info("Starting training on %s", device)
+    if device.type == "cuda":
+        # free any cached memory from previous runs
+        torch.cuda.empty_cache()
     model.to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
     criterion = nn.MSELoss()
@@ -65,10 +68,17 @@ def train_model(
     if resume and latest_file.exists():
         logger.info("Resuming from %s", latest_file)
         ckpt = torch.load(latest_file, map_location=device)
-        model.load_state_dict(ckpt["model_state"])
-        start_epoch = ckpt.get("epoch", -1) + 1
-        best_loss = ckpt.get("best_loss", best_loss)
-        logger.info("Resumed at epoch %d with best loss %.6f", start_epoch, best_loss)
+        try:
+            model.load_state_dict(ckpt["model_state"])
+        except RuntimeError as err:
+            logger.warning("Failed to load checkpoint: %s", err)
+            logger.warning("Starting from scratch with randomly initialized model")
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+        else:
+            start_epoch = ckpt.get("epoch", -1) + 1
+            best_loss = ckpt.get("best_loss", best_loss)
+            logger.info("Resumed at epoch %d with best loss %.6f", start_epoch, best_loss)
 
     for epoch in range(start_epoch, start_epoch + num_epochs):
         model.train()
@@ -117,6 +127,10 @@ def train_model(
 
         if save_all:
             torch.save(model.state_dict(), save_path / f"checkpoint_epoch_{epoch+1}.pth")
+
+        if device.type == "cuda":
+            # release cached memory after each epoch
+            torch.cuda.empty_cache()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- free CUDA cache at start and end of each epoch
- handle checkpoint shape mismatches gracefully to avoid crashing

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*