### PR TITLE
Add configurable LR scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ The `train_compression.py` script writes checkpoints to the `models/` directory.
 Every run saves `latest.pth` and `best.pth` so training can resume where it left
 off. By default the next invocation will load `latest.pth` and continue
 training. Use `--no-resume` to start from scratch or `--save-all` to keep a
-checkpoint for every epoch.
+checkpoint for every epoch. The script also supports a simple learning rate
+schedule via `--lr-decay-step` and `--lr-decay-gamma`, which enable a
+`StepLR` policy from PyTorch.
 
 ## Motivation
 QuatNet was inspired by the ICLR 2019 paper [*Quaternion Recurrent Neural Networks*](https://arxiv.org/abs/1806.04418), which noted that Quaternion neural networks, while computationally intensive due to the Hamilton product, could outperform real-valued networks with a properly engineered CUDA kernel. The **HamProd Kernel** addresses this by providing a high-performance, GPU-accelerated implementation, enabling QNNs to process data with fewer parameters and faster training/inference times.


### PR DESCRIPTION
## Summary
- allow learning rate scheduling with StepLR in `train_compression.py`
- expose `--lr-decay-step` and `--lr-decay-gamma` CLI flags
- document scheduler options in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*