### PR TITLE
Streamline build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,41 +1,29 @@
 cmake_minimum_required(VERSION 3.18)
-project(QuatNetIsokawa LANGUAGES CXX CUDA)
+project(QuatNet LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
 
-# Find CUDA
-find_package(CUDA REQUIRED)
+find_package(CUDAToolkit REQUIRED)
 
-# Set CUDA architectures (A6000 is sm_86)
-set(CMAKE_CUDA_ARCHITECTURES 86) # Adjust if targeting other GPUs
+# Set target GPU architecture; adjust as needed
+set(CMAKE_CUDA_ARCHITECTURES 86)
 
-# Include directories
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${CUDA_INCLUDE_DIRS}
-)
-
-# Add sources for the library
-set(QUATNET_ISOKAWA_SRCS
-    src/quaternion_math.cu # If it has global kernels or host functions needing CUDA compilation
+set(QUATNET_SOURCES
+    src/hamprod_kernel.cu
     src/isokawa_layer.cu
+    src/quat_ops.cu
+    src/quatnet_layer.cu
 )
 
-# Create a shared library for Python bindings
-add_library(isokawa_cuda SHARED ${QUATNET_ISOKAWA_SRCS})
+add_library(quatnet_cuda STATIC ${QUATNET_SOURCES})
+target_include_directories(quatnet_cuda PUBLIC ${PROJECT_SOURCE_DIR}/src)
+target_link_libraries(quatnet_cuda PUBLIC CUDA::cudart)
+set_target_properties(quatnet_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
-# Link CUDA libraries
-target_link_libraries(isokawa_cuda PRIVATE ${CUDA_LIBRARIES} ${CUDA_cudart_static_LIBRARY}) # Or ${CUDA_CUDA_LIBRARY}
+add_executable(quatnet_example src/main.cpp)
+target_link_libraries(quatnet_example PRIVATE quatnet_cuda CUDA::cudart)
 
-# Enable separable compilation if needed (usually good for larger projects)
-set_target_properties(isokawa_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-
-# Optional: An executable for testing C++ components
-# add_executable(isokawa_test src/main.cpp ${QUATNET_ISOKAWA_SRCS})
-# target_link_libraries(isokawa_test PRIVATE ${CUDA_LIBRARIES} ${CUDA_cudart_static_LIBRARY})
-# set_target_properties(isokawa_test PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
-
-# Installation (optional, for system-wide install or packaging)
-# install(TARGETS isokawa_cuda LIBRARY DESTINATION lib)
-# install(FILES src/quaternion_math.h src/isokawa_layer.h DESTINATION include/QuatNetIsokawa)
+add_executable(hamprod_tests tests/hamprod_tests.cpp)
+target_link_libraries(hamprod_tests PRIVATE quatnet_cuda CUDA::cudart)
+add_test(NAME hamprod_tests COMMAND hamprod_tests)

--- a/src/quat_ops.cu
+++ b/src/quat_ops.cu
@@ -2,25 +2,4 @@
 #include "quat_ops.h"
 #include "utils.h" // For CUDA_CHECK if used here
 
-// Example: If you had a global kernel for element-wise product
-/*
-__global__ void elementwiseHamprodKernel_math(const Quaternion* __restrict__ A,
-                                          const Quaternion* __restrict__ B,
-                                          Quaternion* __restrict__ C,
-                                          int N) {
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < N) {
-        C[idx] = A[idx] * B[idx]; // Uses overloaded __device__ operator*
-    }
-}
-
-void launchElementwiseHamprod(const Quaternion* A, const Quaternion* B,
-                              Quaternion* C, int N) {
-    dim3 blockDim(256);
-    dim3 gridDim((N + blockDim.x - 1) / blockDim.x);
-    elementwiseHamprodKernel_math<<<gridDim, blockDim>>>(A, B, C, N);
-    // CUDA_CHECK(cudaGetLastError()); // Good practice
-}
-*/
-// For now, this file might be minimal if most quaternion math is __device__
-// and directly used within the Isokawa layer kernels.
+// Additional quaternion kernels could be implemented here if needed.


### PR DESCRIPTION
## Summary
- clean up unused quaternion ops file
- modernize CMake build and include all CUDA sources

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*