### PR TITLE
Fix CUDA build sources and unify Quaternion struct

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
             sources=[
                 'src/bindings.cpp',
                 'src/quat_ops.cu',
+                'src/quatnet_layer.cu',
+                'src/hamprod_kernel.cu',
             ],
             include_dirs=[
                 cuda_include_dir,

--- a/src/hamprod_kernel.h
+++ b/src/hamprod_kernel.h
@@ -1,9 +1,8 @@
 // hamprod_kernel.h
 #pragma once
 
-struct Quaternion {
-    float w, x, y, z;
-};
+
+#include "quat_ops.h"
 
 void launchHamprod(const Quaternion* A, const Quaternion* B,
                    Quaternion* C, int N);


### PR DESCRIPTION
## Summary
- ensure hamprod kernel uses Quaternion from quat_ops
- expose CUDA sources in setup.py build
- add optional CUDA backend to the PyTorch layer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `cmake ..` *(fails: Failed to find nvcc)*