### PR TITLE
Add remote CI defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Remote CI Agent
+
+This repository uses a remote CI build and test system.
+
+## Trigger
+Run the remote CI whenever you see instructions like "run remote CI" or "build+test on server".
+
+## Action
+Execute `scripts/remote-ci.sh` locally. The script SSHs into the remote machine and performs the build and tests there.
+
+## Environment variables
+- `CI_SSH_HOST`: Hostname or IP address of the remote server.
+- `CI_SSH_USER`: SSH user to log in as.
+- `CI_REPO_PATH`: Path to this repository on the remote server.
+
+## Example
+```bash
+export CI_SSH_HOST=100.111.229.14
+export CI_SSH_USER=jake
+export CI_REPO_PATH=~/Developer/QuatNet/commotum-quatnet
+bash scripts/remote-ci.sh
+```

--- a/scripts/remote-ci.sh
+++ b/scripts/remote-ci.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Run CI build and tests on a remote server via SSH.
+# Requires the following environment variables:
+#   CI_SSH_HOST - Hostname or IP of the remote server
+#   CI_SSH_USER - SSH user to connect as
+#   CI_REPO_PATH - Path to the repository on the remote server
+
+set -e
+
+# Default configuration. Override by setting the environment variables before
+# calling this script.
+CI_SSH_HOST="${CI_SSH_HOST:-100.111.229.14}"
+CI_SSH_USER="${CI_SSH_USER:-jake}"
+CI_REPO_PATH="${CI_REPO_PATH:-~/Developer/QuatNet/commotum-quatnet}"
+
+ssh "${CI_SSH_USER}@${CI_SSH_HOST}" bash -s <<EOF2
+set -e
+cd "${CI_REPO_PATH}"
+rm -rf build
+mkdir build
+cd build
+cmake .. && make -j\$(nproc)
+python -m pytest -q
+EOF2
+
+exit_code=$?
+exit $exit_code
+


### PR DESCRIPTION
## Summary
- update `AGENTS.md` example with server IP
- make `scripts/remote-ci.sh` use default env vars for your server

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*