### PR TITLE
Fix CUDA helper visibility

### DIFF
--- a/src/quat_ops.h
+++ b/src/quat_ops.h
@@ -53,7 +53,6 @@ struct Quaternion {
     }
 };
 
-#ifdef __CUDA_ARCH__
 // Atomic addition for Quaternion values (device only)
 __device__ inline void atomicAddQuaternion(Quaternion* addr, const Quaternion& val) {
     atomicAdd(&(addr->w), val.w);
@@ -61,15 +60,13 @@ __device__ inline void atomicAddQuaternion(Quaternion* addr, const Quaternion& v
     atomicAdd(&(addr->y), val.y);
     atomicAdd(&(addr->z), val.z);
 }
-#endif
 
-#ifdef __CUDA_ARCH__
 // Device-side sigmoid for individual components
 __device__ inline float device_component_sigmoid(float val) {
     return 1.0f / (1.0f + expf(-val));
 }
+
 // Device-side tanh for individual components
 __device__ inline float device_component_tanh(float val) {
     return tanhf(val);
 }
-#endif


### PR DESCRIPTION
## Summary
- expose quaternion CUDA helper functions outside of `__CUDA_ARCH__`

## Testing
- `cmake ..` *(fails: Failed to find nvcc)*